### PR TITLE
Updates package manifest for VPM dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,18 +1,21 @@
 {
 	"name": "dev.onevr.vrworldtoolkit",
-	"version": "2.1.1",
+	"version": "2.1.2",
 	"displayName": "VRWorld Toolkit",
 	"description": "VRWorld Toolkit is a Unity Editor extension made to make VRChat world creation more accessible and lower the entry-level to make a good performing world.",
 	"unity": "2019.4",
 	"documentationUrl": "https://github.com/oneVR/VRWorldToolkit",
 	"licensesUrl": "https://github.com/oneVR/VRWorldToolkit/blob/master/LICENSE",
-	"dependencies": {
-		"com.vrchat.base" : "https://github.com/vrchat/com.vrchat.base.git"
+	"vpmDependencies": {
+		"com.vrchat.base" : "3.1.x"
 	},
 	"url" : "https://github.com/oneVR/VRWorldToolkit.git#vpm",
 	"author": {
 		"name": "oneVRdev",
 		"email": "15145@pm.me",
 		"url": "https://oneVR.dev/"
+	},
+	"legacyFolders": {
+		"Assets\\VRWorldToolkit": "fb6f58799fddd184a94ea8cd32c9db5a"
 	}
 }


### PR DESCRIPTION
- Increments version to 2.1.1
- Changes 'dependencies' to 'vpmDependencies' and uses new range syntax to require any version from 3.1.0 and up
- Includes 'legacyFolders' item, which should allow seamless inclusion of new package when migrating legacy projects once VRWorldToolkit is listed in Curated Packages.