### PR TITLE
Add Environment Layer to Full Mirror Quick Set

### DIFF
--- a/Editor/CustomMirrorEditor.cs
+++ b/Editor/CustomMirrorEditor.cs
@@ -34,9 +34,9 @@ namespace VRWorldToolkit.Editor
 
             EditorGUILayout.BeginHorizontal();
 
-            if (GUILayout.Button("Show only players")) MirrorLayerChange(262656);
+            if (GUILayout.Button("Show only Players")) MirrorLayerChange(262656);
 
-            if (GUILayout.Button("Show players/world")) MirrorLayerChange(262657);
+            if (GUILayout.Button("Show Players/World")) MirrorLayerChange(264705);
 
             EditorGUILayout.EndHorizontal();
 
@@ -60,13 +60,14 @@ namespace VRWorldToolkit.Editor
                     EditorGUILayout.HelpBox("PlayerLocal is only meant to be seen in first-person view and should not be enabled on mirrors.", MessageType.Error);
             }
 
-            showExplanations = EditorGUILayout.Foldout(showExplanations, "VRChat specific layer explanations");
+            showExplanations = EditorGUILayout.Foldout(showExplanations, "VRChat Specific Layer Explanations");
 
             if (showExplanations)
             {
-                GUILayout.Label("<b>Player:</b>\nThis layer is used for other players than yourself", Styles.RichTextWrap);
-                GUILayout.Label("<b>PlayerLocal:</b>\nThis layer is only used for first-person view and should not be enabled in mirrors", Styles.RichTextWrap);
-                GUILayout.Label("<b>MirrorReflection:</b>\nThis layer is used for your own mirror version", Styles.RichTextWrap);
+                GUILayout.Label("<b>Player:</b>\nThis layer is used to show players other than yourself.", Styles.RichTextWrap);
+                GUILayout.Label("<b>PlayerLocal:</b>\nThis layer is only used for first-person view and should not be enabled in mirrors.", Styles.RichTextWrap);
+                GUILayout.Label("<b>Environment:</b>\nThis layer is used for static meshes and objects in the world. Shares the same properties as the Default layer.", Styles.RichTextWrap);
+                GUILayout.Label("<b>MirrorReflection:</b>\nThis layer is used to fully show your own self in the mirror.", Styles.RichTextWrap);
             }
 
             serializedObject.ApplyModifiedProperties();


### PR DESCRIPTION
This changes the integer on the "Show Players/World" Button to also include `Environment`, in addition to `Default`, `Player`, and `MirrorReflection`. This was done because `Environment` is officially considered by VRChat as a Layer that can be used for Static Meshes in a World... as it shares the same exact Collision Matrix as `Default`.

In addition, I've added a new line to the Specific Layer Explanations detailing what `Environment` is used for. I've also done some proofreading as well.