### PR TITLE
Updated Layer Warnings for the VRC Mirror Reflection Script (CustomMirrorEditor.cs)

### DIFF
--- a/Editor/CustomMirrorEditor.cs
+++ b/Editor/CustomMirrorEditor.cs
@@ -1,4 +1,4 @@
-﻿#if !VRWT_DISABLE_EDITORS
+#if !VRWT_DISABLE_EDITORS
 using VRC.SDKBase;
 using UnityEditor;
 using UnityEngine;
@@ -28,16 +28,18 @@ namespace VRWorldToolkit.Editor
 
             EditorGUILayout.Space();
 
-            EditorGUILayout.LabelField("VRWorld Toolkit Additions", EditorStyles.boldLabel);
+            EditorGUILayout.LabelField("VRWorld Toolkit Additions", EditorStyles.largeLabel);
 
-            EditorGUILayout.LabelField("Quick set Reflect Layers:");
-
+            EditorGUILayout.LabelField("Quick-Set Reflect Layers:");
+            
+            EditorGUILayout.LabelField("This function will set the necessary Reflect Layers on this Mirror for optimal performance. If you are new to creating worlds, we highly recommend choosing one of these options.", Styles.HelpBoxRichText);
+            
             EditorGUILayout.BeginHorizontal();
 
             if (GUILayout.Button("Show only Players")) MirrorLayerChange(262656);
 
             if (GUILayout.Button("Show Players/World")) MirrorLayerChange(264705);
-
+            
             EditorGUILayout.EndHorizontal();
 
             if (Selection.gameObjects.Length == 1)
@@ -47,14 +49,11 @@ namespace VRWorldToolkit.Editor
                 if ((LightmapSettings.lightProbes != null && LightmapSettings.lightProbes.positions.Length == 0 && currentMirror.m_DisablePixelLights) || (LightmapSettings.lightProbes is null && currentMirror.m_DisablePixelLights))
                     EditorGUILayout.HelpBox("No baked light probes were found in lighting data. Dynamic objects such as players and pickups will not appear lit in mirrors without baked light probes.", MessageType.Warning);
 
-                if (mirrorMask.intValue == -1025)
-                    EditorGUILayout.HelpBox("This mirror has default layers set. Unnecessary layers should be disabled to save on performance.", MessageType.Info);
-                    
                 if (mirrorMask.intValue == ~0)
-                    EditorGUILayout.HelpBox("This mirror has it's Reflect Layers set to Everything. This can lead to degraded performance in populated instances! Unnecessary Reflect Layers should be disabled to save on performance.", MessageType.Error);
+                    EditorGUILayout.HelpBox("This mirror has it's Reflect Layers set to Everything. This can lead to degraded performance in populated instances!\nYou should consider disabling unnecessary Reflect Layers to save on performance. Perhaps you can use the Quick-Set Reflect Layer Utility above?", MessageType.Error);
 
                 if (Helper.LayerIncludedInMask(LayerMask.NameToLayer("UiMenu"), mirrorMask.intValue))
-                    EditorGUILayout.HelpBox("Having UiMenu enabled on mirrors causes Nameplates to be rendered twice and should not be enabled on mirrors.", MessageType.Warning);
+                    EditorGUILayout.HelpBox("Having UiMenu enabled on mirrors causes Nameplates to be rendered twice. It should never be enabled on mirrors.", MessageType.Warning);
                 
                 if (Helper.LayerIncludedInMask(LayerMask.NameToLayer("reserved2"), mirrorMask.intValue))
                     EditorGUILayout.HelpBox("Having reserved2 enabled on mirrors causes the VRChat HUD, Main Menu and Tooltips to be rendered twice, causing a noticeable performance drop in populated instances.", MessageType.Warning);
@@ -63,17 +62,20 @@ namespace VRWorldToolkit.Editor
                     EditorGUILayout.HelpBox("Having the MirrorReflection layer disabled will stop the player from seeing themselves in the mirror.", MessageType.Warning);
 
                 if (Helper.LayerIncludedInMask(LayerMask.NameToLayer("PlayerLocal"), mirrorMask.intValue))
-                    EditorGUILayout.HelpBox("PlayerLocal is only meant to be seen in first-person view and should not be enabled in mirrors.", MessageType.Error);
+                    EditorGUILayout.HelpBox("PlayerLocal is only meant to be seen in first-person view and will not render in mirrors. Use MirrorReflection instead.", MessageType.Error);
+                
+                if (Helper.LayerIncludedInMask(LayerMask.NameToLayer("Water"), mirrorMask.intValue))
+                    EditorGUILayout.HelpBox("Objects that are in the Water layer are never rendered in mirrors!", MessageType.Error);
             }
 
             showExplanations = EditorGUILayout.Foldout(showExplanations, "VRChat Specific Layer Descriptions");
 
             if (showExplanations)
             {
+                EditorGUILayout.HelpBox("These VRChat-specific Layers used in the mirror are described below. Only the Default and Environment layer will be used in addition if you choose to Show Players/World.\nDo not use other Layers in the mirror unless you know what you are doing!", MessageType.Info);
                 GUILayout.Label("<b>Player:</b>\nThis layer is used to show players other than yourself.", Styles.RichTextWrap);
-                GUILayout.Label("<b>PlayerLocal:</b>\nThis layer is only used for first-person view and should not be enabled in mirrors.", Styles.RichTextWrap);
                 GUILayout.Label("<b>Environment:</b>\nThis layer is used for static meshes and objects in the world. Shares the same properties as the Default layer.", Styles.RichTextWrap);
-                GUILayout.Label("<b>MirrorReflection:</b>\nThis layer is used to fully show your own self in the mirror.", Styles.RichTextWrap);
+                GUILayout.Label("<b>MirrorReflection:</b>\nThis layer is used to show render your own self in the mirror.", Styles.RichTextWrap);
             }
 
             serializedObject.ApplyModifiedProperties();

--- a/Editor/CustomMirrorEditor.cs
+++ b/Editor/CustomMirrorEditor.cs
@@ -49,15 +49,21 @@ namespace VRWorldToolkit.Editor
 
                 if (mirrorMask.intValue == -1025)
                     EditorGUILayout.HelpBox("This mirror has default layers set. Unnecessary layers should be disabled to save on performance.", MessageType.Info);
+                    
+                if (mirrorMask.intValue == ~0)
+                    EditorGUILayout.HelpBox("This mirror has it's Reflect Layers set to Everything. This can lead to degraded performance in populated instances! Unnecessary Reflect Layers should be disabled to save on performance.", MessageType.Error);
 
                 if (Helper.LayerIncludedInMask(LayerMask.NameToLayer("UiMenu"), mirrorMask.intValue))
-                    EditorGUILayout.HelpBox("Having UiMenu enabled on mirrors causes VRChat UI elements to be rendered twice, causing a noticeable performance drop in populated instances.", MessageType.Warning);
+                    EditorGUILayout.HelpBox("Having UiMenu enabled on mirrors causes Nameplates to be rendered twice and should not be enabled on mirrors.", MessageType.Warning);
+                
+                if (Helper.LayerIncludedInMask(LayerMask.NameToLayer("reserved2"), mirrorMask.intValue))
+                    EditorGUILayout.HelpBox("Having reserved2 enabled on mirrors causes the VRChat HUD, Main Menu and Tooltips to be rendered twice, causing a noticeable performance drop in populated instances.", MessageType.Warning);
 
                 if (!Helper.LayerIncludedInMask(LayerMask.NameToLayer("MirrorReflection"), mirrorMask.intValue))
                     EditorGUILayout.HelpBox("Having the MirrorReflection layer disabled will stop the player from seeing themselves in the mirror.", MessageType.Warning);
 
                 if (Helper.LayerIncludedInMask(LayerMask.NameToLayer("PlayerLocal"), mirrorMask.intValue))
-                    EditorGUILayout.HelpBox("PlayerLocal is only meant to be seen in first-person view and should not be enabled on mirrors.", MessageType.Error);
+                    EditorGUILayout.HelpBox("PlayerLocal is only meant to be seen in first-person view and should not be enabled in mirrors.", MessageType.Error);
             }
 
             showExplanations = EditorGUILayout.Foldout(showExplanations, "VRChat Specific Layer Descriptions");

--- a/Editor/CustomMirrorEditor.cs
+++ b/Editor/CustomMirrorEditor.cs
@@ -50,22 +50,28 @@ namespace VRWorldToolkit.Editor
                     EditorGUILayout.HelpBox("No baked light probes were found in lighting data. Dynamic objects such as players and pickups will not appear lit in mirrors without baked light probes.", MessageType.Warning);
 
                 if (mirrorMask.intValue == ~0)
-                    EditorGUILayout.HelpBox("This mirror has it's Reflect Layers set to Everything. This can lead to degraded performance in populated instances!\nYou should consider disabling unnecessary Reflect Layers to save on performance. Perhaps you can use the Quick-Set Reflect Layer Utility above?", MessageType.Error);
+                    EditorGUILayout.HelpBox("This mirror has it's Reflect Layers set to Everything. This can lead to degraded performance in populated instances!\nConsider disabling unnecessary Reflect Layers to save on performance. Perhaps you should use the Quick-Set Reflect Layer Utility above?", MessageType.Error);
 
                 if (Helper.LayerIncludedInMask(LayerMask.NameToLayer("UiMenu"), mirrorMask.intValue))
                     EditorGUILayout.HelpBox("Having UiMenu enabled on mirrors causes Nameplates to be rendered twice. It should never be enabled on mirrors.", MessageType.Warning);
                 
                 if (Helper.LayerIncludedInMask(LayerMask.NameToLayer("reserved2"), mirrorMask.intValue))
-                    EditorGUILayout.HelpBox("Having reserved2 enabled on mirrors causes the VRChat HUD, Main Menu and Tooltips to be rendered twice, causing a noticeable performance drop in populated instances.", MessageType.Warning);
+                    EditorGUILayout.HelpBox("Having reserved2 enabled on mirrors causes the VRChat HUD, Main Menu and Tooltips to be rendered twice, causing a noticeable performance drop in populated instances. It should never be enabled on mirrors.", MessageType.Warning);
 
                 if (!Helper.LayerIncludedInMask(LayerMask.NameToLayer("MirrorReflection"), mirrorMask.intValue))
                     EditorGUILayout.HelpBox("Having the MirrorReflection layer disabled will stop the player from seeing themselves in the mirror.", MessageType.Warning);
 
                 if (Helper.LayerIncludedInMask(LayerMask.NameToLayer("PlayerLocal"), mirrorMask.intValue))
-                    EditorGUILayout.HelpBox("PlayerLocal is only meant to be seen in first-person view and will not render in mirrors. Use MirrorReflection instead.", MessageType.Error);
+                    EditorGUILayout.HelpBox("PlayerLocal is only meant to be seen in first-person view and will never render in mirrors. Use MirrorReflection instead.", MessageType.Error);
                 
                 if (Helper.LayerIncludedInMask(LayerMask.NameToLayer("Water"), mirrorMask.intValue))
                     EditorGUILayout.HelpBox("Objects that are in the Water layer are never rendered in mirrors!", MessageType.Error);
+                
+                if (mirrorMask.intValue == 262656)
+                    EditorGUILayout.HelpBox("This Mirror is properly set to show only Players.", MessageType.Info);
+                
+                if (mirrorMask.intValue == 264705)
+                    EditorGUILayout.HelpBox("This Mirror is properly set to show both Players and the World.", MessageType.Info);
             }
 
             showExplanations = EditorGUILayout.Foldout(showExplanations, "VRChat Specific Layer Descriptions");


### PR DESCRIPTION
Based on my research, it has come to my attention that one of the Layer Warnings are somewhat inaccurate as of late. I have made changes to reflect this.

**Most notably, VRChat has moved all of it's HUD, Main Menu, and Tooltips to a different Layer a long time ago.** Since VRChat `v2021.4.2 (Build 1156)`, they moved these UI elements to `reserved2` in order to make it completely immune to Post Processing Volumes and other effects. And since it is still known that performance can be degraded if it's UI elements are reflected in the Mirror, I added a warning when the `reserved2` Layer is enabled, advising users to refrain from using it.

Since the `UiMenu` is still used for Nameplates, I modified the warning for this Layer as well to reflect this.

Lastly, I've also modified the warning against Mirrors with it's Reflect Layers set to `Everything` as a safety procedure. It warns that performance may be heavily degraded if all Reflect Layers are enabled at the same time. I did this because the `VRCMirror.prefab` in the SDK Examples still has Everything set by default (and the old warning doesn't work anymore for some reason).

I've also added some other Warnings and Tooltips that I think are relevant. See the Changelog below for more info.

**Changelog:**
- Added a warning to Mirrors if it's Reflect Layers are set to Everything, and will warn users in the Editor if so.
- Added a warning against using the reserved2 layer, which VRChat now uses for it's HUD, Main Menu, Tooltips and it's User Interface.
- Added a warning against using the Water layer, since Mirrors already refuse to render any object in the Water layer.
- Modified the warning for the UiMenu layer as it still currently shows Nameplates.
- Modified the warning for the PlayerLocal layer. Mirrors refuse to render PlayerLocal layer anymore for some reason (because it makes you look headless?).
- Refined the VRChat Specific Layer Descriptions with some clarified information, including a Tip on what would be used if using "Show Players/World" as well.
- Depending on which button was pressed, whether that'd be "Show only Players" or "Show Players/World", an Information Message will now appear telling you that it's set correctly.