### PR TITLE
Fix Build Report Summary Clicking

### DIFF
--- a/Editor/WorldDebugger.cs
+++ b/Editor/WorldDebugger.cs
@@ -2884,6 +2884,7 @@ namespace VRWorldToolkit.Editor
         };
         
         [SerializeField] private BuildReportType selectedBuildReport;
+        [SerializeField] private BuildReportType previousSelectedBuildReport;
         [SerializeField] private bool overallStatsFoldout;
         [SerializeField] private bool buildReportMessagesFoldout;
         
@@ -3058,12 +3059,10 @@ namespace VRWorldToolkit.Editor
                 GUILayout.BeginVertical();
 
                 GUILayout.BeginHorizontal(EditorStyles.toolbar);
-                
-                EditorGUI.BeginChangeCheck();
 
                 selectedBuildReport = (BuildReportType)EditorGUILayout.Popup((int)selectedBuildReport, BuildReportSelectionDropdown, EditorStyles.toolbarPopup);
 
-                if (EditorGUI.EndChangeCheck())
+                if (selectedBuildReport != previousSelectedBuildReport)
                 {
                     switch (selectedBuildReport)
                     {
@@ -3077,6 +3076,8 @@ namespace VRWorldToolkit.Editor
                             buildReportTreeView.SetReport(buildReportiOS);
                             break;
                     }
+                    
+                    previousSelectedBuildReport = selectedBuildReport;
                 }
                 
                 GUILayout.Space(10);


### PR DESCRIPTION
The build report has summary boxes at the top labeled "Last Windows build:", "Last Android build:", etc.
Clicking the summary boxes changes the dropdown field for the build report, but it does not actually change the contents of the file list.
I replaced the Unity ChangeCheck with a manual check which allows a change to `selectedBuildReport` to be detected even if it is changed elsewhere in the code.