### PR TITLE
Add handling for param in FindRenderSettingsStorage in updated Bakery

### DIFF
--- a/Editor/BakeryCompat.cs
+++ b/Editor/BakeryCompat.cs
@@ -30,7 +30,7 @@ namespace VRWorldToolkit.Editor
             if (ftRenderLightmap == null) return (null, null);
 
             var method = ftRenderLightmap.GetMethod("FindRenderSettingsStorage", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
-            var renderSettingsStorage = method?.Invoke(null, null);
+            var renderSettingsStorage = method?.Invoke(null, new object[method?.GetParameters()?.Length ?? 0]);
             return (renderSettingsStorage, ftRenderLightmap);
         }
 


### PR DESCRIPTION
Hello,

Thank you for the recent release.
I found that with Bakery updated via the github patches, the new BakeryCompat reflection in VRWorldTookit throws an exception due to a parameter being added to `FindRenderSettingsStorage`.
This is the new signature:
```
public static ftLightmapsStorage FindRenderSettingsStorage(GameObject forSceneObject = null)
```

This hack is somewhat inelegant but will allow VRWorldToolkit to work with both versions. (feel free to close this if you would rather have a more proper solution).

