### PR TITLE
Per-plaform overrides for MassTextureImporter

### DIFF
--- a/Editor/MassTextureImporter.cs
+++ b/Editor/MassTextureImporter.cs
@@ -388,684 +388,146 @@ namespace VRWorldToolkit.Editor
             public int MaxTextureSize = 2048;
             public bool CrunchCompression = true;
             public int CompressionQuality = 80;
-        }using System;
-        using System.Collections.Generic;
-        using System.IO;
-        using System.Linq;
-        using UnityEditor;
-        using UnityEngine;
+        }
+    }
 
-        namespace Editor
+
+    public class MassTextureImporter : EditorWindow
+    {
+        private TextureDetails details = new();
+
+        private ImporterSettingsManager importerSettingsManager = new();
+
+        private Vector2 scrollPos;
+
+        private void OnGUI()
         {
-
-        public class TextureDetails
-        {
-            private readonly Dictionary<Texture, TextureImporter> textureList = new();
-            private int? cubemaps;
-            private int? normalMaps;
-            private long? storageSize;
-            private int? uncrunchedCount;
-
-            public int TextureCount => textureList.Count;
-
-            public int UncrunchedCount
+            GUILayout.Label("Selected Textures", Styles.BoldWrap);
+            using (new EditorGUILayout.HorizontalScope(EditorStyles.helpBox))
             {
-                get
+                using (new EditorGUILayout.VerticalScope())
                 {
-                    if (uncrunchedCount is null) uncrunchedCount = textureList.Count(x => !x.Value.crunchedCompression);
+                    GUILayout.Label("<b>Texture Count:</b> " + details.TextureCount, Styles.LabelRichText);
+                    GUILayout.Label("<b>Uncrunched Count:</b> " + details.UncrunchedCount, Styles.LabelRichText);
+                    GUILayout.Label("<b>Storage Size:</b> " + EditorUtility.FormatBytes(details.StorageSize),
+                        Styles.LabelRichText);
+                }
 
-                    return (int)uncrunchedCount;
+                using (new EditorGUILayout.VerticalScope())
+                {
+                    GUILayout.Label("<b>Normal Maps:</b> " + details.NormalMaps, Styles.LabelRichText);
+                    GUILayout.Label("<b>Cubemaps:</b> " + details.Cubemaps, Styles.LabelRichText);
                 }
             }
 
-            public int NormalMaps
+            importerSettingsManager.DrawSettings();
+
+            GUILayout.Space(5);
+
+            GUILayout.Label("Get textures from:");
+
+            using (new EditorGUILayout.HorizontalScope())
             {
-                get
-                {
-                    if (normalMaps is null)
-                        normalMaps = textureList.Count(x => x.Value.textureType == TextureImporterType.NormalMap);
+                if (GUILayout.Button("Scene", GUILayout.Width(70), GUILayout.Height(20)))
+                    details = GetAllTexturesFromScene();
 
-                    return (int)normalMaps;
-                }
-            }
+                if (GUILayout.Button("Assets", GUILayout.Width(70), GUILayout.Height(20)))
+                    details = GetAllTexturesFromAssets();
 
-            public int Cubemaps
-            {
-                get
-                {
-                    if (cubemaps is null)
-                        cubemaps = textureList.Count(x => x.Value.textureShape == TextureImporterShape.TextureCube);
+                GUILayout.FlexibleSpace();
 
-                    return (int)cubemaps;
-                }
-            }
+                if (GUILayout.Button("Revert", GUILayout.Width(70), GUILayout.Height(20)))
+                    importerSettingsManager = new ImporterSettingsManager();
 
-            public long StorageSize
-            {
-                get
-                {
-                    if (storageSize is null)
-                        storageSize = textureList.Sum(x => EditorTextureUtil.GetStorageMemorySize(x.Key));
-
-                    return (long)storageSize;
-                }
-            }
-
-            public IEnumerable<TextureImporter> GetImporters
-            {
-                get { return textureList.Select(x => x.Value).ToArray(); }
-            }
-
-            public void AddTexture(TextureImporter textureImporter, Texture texture)
-            {
-                if (!textureList.ContainsKey(texture) && textureImporter != null)
-                    textureList.Add(texture, textureImporter);
-            }
-
-            public void ResetStats()
-            {
-                uncrunchedCount = null;
-                storageSize = null;
+                if (GUILayout.Button("Apply", GUILayout.Width(70), GUILayout.Height(20)))
+                    if (EditorUtility.DisplayDialog("Process Importers?",
+                            $"About to process Texture Import settings on {details.TextureCount} textures, this can take a while depending on the amount and size of them.\n\nDo you want to continue?",
+                            "Ok", "Cancel"))
+                        importerSettingsManager.ProcessTextures(details);
             }
         }
 
-        public class ImporterSettingsManager
+        [MenuItem("VRWorld Toolkit/Quick Functions/Mass Texture Importer", false, 4)]
+        public static void ShowWindow()
         {
-            public enum DontOverrideWhen
+            var window = GetWindow(typeof(MassTextureImporter));
+            window.titleContent = new GUIContent("Mass Texture Importer");
+            window.minSize = new Vector2(400, 530);
+            window.Show();
+        }
+
+        private static TextureDetails GetAllTexturesFromScene()
+        {
+            var details = new TextureDetails();
+            var checkedMaterials = new List<Material>();
+
+            var allGameObjects = Resources.FindObjectsOfTypeAll(typeof(GameObject));
+            var allGameObjectsLength = allGameObjects.Length;
+            for (var i = 0; i < allGameObjectsLength; i++)
             {
-                Never,
-                AlreadyDisabled,
-                AlreadyEnabled
-            }
+                var gameObject = allGameObjects[i] as GameObject;
 
-            public enum OverrideWhenSize
-            {
-                Always,
-                SmallerThan,
-                BiggerThan
-            }
+                if (gameObject.hideFlags != HideFlags.None ||
+                    EditorUtility.IsPersistent(gameObject.transform.root.gameObject)) continue;
 
-            private readonly string[] maxTextureNames =
-                { "32", "64", "128", "256", "512", "1024", "2048", "4096", "8192" };
+                if (EditorUtility.DisplayCancelableProgressBar("Getting All Textures from Scene", gameObject.name,
+                        (float)i / allGameObjectsLength)) break;
 
-            private readonly int[] maxTextureSizes = { 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192 };
-
-            // Mip Maps
-            public bool DontChangeMipMaps { get; private set; }
-            public bool StreamingMipMap { get; private set; } = true;
-            public bool GenerateMipMaps { get; private set; } = true;
-            public bool DontChangeAniso { get; private set; } = true;
-            public int AnisoLevel { get; private set; } = 1;
-            public OverrideWhenSize OverrideAnisoWhen { get; private set; }
-
-            // Max Texture Size (default)
-            public int MaxTextureSize { get; private set; } = 2048;
-            public OverrideWhenSize OverrideMaxTextureSizeWhen { get; private set; } = OverrideWhenSize.BiggerThan;
-
-            // Crunch compression (default)
-            public bool CrunchCompression { get; private set; } = true;
-            public int CompressionQuality { get; private set; } = 80;
-            public DontOverrideWhen DontOverrideCrunchWhen { get; private set; } = DontOverrideWhen.AlreadyEnabled;
-
-            public OverrideWhenSize OverrideCrunchCompressionSizeWhen { get; private set; } =
-                OverrideWhenSize.BiggerThan;
-
-            // Texture Compression Format (default)
-            public bool DontChangeCompressionQuality { get; private set; } = true;
-
-            public TextureImporterCompression TextureCompressionQuality { get; private set; } =
-                TextureImporterCompression.Compressed;
-
-            public bool ignoreNoneCompression { get; private set; }
-
-            // Ignores
-            public bool IgnoreCubemaps { get; private set; } = true;
-            public OverrideWhenSize OverrideCubemapSettingsWhen { get; private set; } = OverrideWhenSize.SmallerThan;
-            public int CubemapSize { get; private set; } = 512;
-            public bool IgnoreNormalMaps { get; private set; } = true;
-
-            // PC = Standalone
-            public PlatformOverrideSettings StandaloneSettings { get; } = new();
-            public PlatformOverrideSettings AndroidSettings { get; } = new();
-            public PlatformOverrideSettings iOSSettings { get; } = new();
-
-            public void DrawSettings()
-            {
-                GUILayout.Label("Mip Maps", Styles.BoldWrap);
-                DontChangeMipMaps = EditorGUILayout.Toggle("Don't Change", DontChangeMipMaps);
-                using (new EditorGUI.DisabledScope(DontChangeMipMaps))
+                var renderers = gameObject.GetComponents<Renderer>();
+                for (var j = 0; j < renderers.Length; j++)
                 {
-                    StreamingMipMap = EditorGUILayout.Toggle("Streaming Mip Maps", StreamingMipMap);
-                    GenerateMipMaps = EditorGUILayout.Toggle("Generate Mip Maps", GenerateMipMaps);
-                }
-
-                GUILayout.Label("Aniso Level", Styles.BoldWrap);
-                DontChangeAniso = EditorGUILayout.Toggle("Don't Change", DontChangeAniso);
-                using (new EditorGUI.DisabledScope(DontChangeAniso))
-                {
-                    AnisoLevel = EditorGUILayout.IntSlider("Aniso Level", AnisoLevel, 0, 16);
-                    using (new EditorGUI.IndentLevelScope())
+                    var renderer = renderers[j];
+                    for (var k = 0; k < renderer.sharedMaterials.Length; k++)
                     {
-                        OverrideAnisoWhen =
-                            (OverrideWhenSize)EditorGUILayout.EnumPopup("Override When", OverrideAnisoWhen);
-                    }
-                }
+                        var material = renderer.sharedMaterials[k];
 
-                GUILayout.Label("Size (Default)", Styles.BoldWrap);
-                MaxTextureSize = EditorGUILayout.IntPopup("Max Size", MaxTextureSize, maxTextureNames, maxTextureSizes);
-                using (new EditorGUI.IndentLevelScope())
-                {
-                    OverrideMaxTextureSizeWhen =
-                        (OverrideWhenSize)EditorGUILayout.EnumPopup("Override When", OverrideMaxTextureSizeWhen);
-                }
-
-                GUILayout.Label("Crunch Compression (Default)", Styles.BoldWrap);
-                CrunchCompression = EditorGUILayout.Toggle("Use Crunch Compression", CrunchCompression);
-                using (new EditorGUI.DisabledScope(!CrunchCompression))
-                {
-                    CompressionQuality = EditorGUILayout.IntSlider("Quality", CompressionQuality, 1, 100);
-                    using (new EditorGUI.IndentLevelScope())
-                    {
-                        OverrideCrunchCompressionSizeWhen =
-                            (OverrideWhenSize)EditorGUILayout.EnumPopup("Override When",
-                                OverrideCrunchCompressionSizeWhen);
-                    }
-                }
-
-                using (new EditorGUI.IndentLevelScope())
-                {
-                    DontOverrideCrunchWhen =
-                        (DontOverrideWhen)EditorGUILayout.EnumPopup("Don't Override When", DontOverrideCrunchWhen);
-                }
-
-                GUILayout.Label("Texture Compression Quality (Default)", Styles.BoldWrap);
-                DontChangeCompressionQuality = EditorGUILayout.Toggle("Dont Change", DontChangeCompressionQuality);
-                using (new EditorGUI.DisabledScope(DontChangeCompressionQuality))
-                {
-                    using (new EditorGUI.IndentLevelScope())
-                    {
-                        TextureCompressionQuality =
-                            (TextureImporterCompression)EditorGUILayout.EnumPopup("Compression Quality",
-                                TextureCompressionQuality);
-                        ignoreNoneCompression = EditorGUILayout.Toggle("Ignore Uncompressed", ignoreNoneCompression);
-                    }
-                }
-
-                GUILayout.Label("Ignore", Styles.BoldWrap);
-                IgnoreCubemaps = EditorGUILayout.Toggle("Cubemaps", IgnoreCubemaps);
-                using (new EditorGUI.IndentLevelScope())
-                {
-                    using (new EditorGUI.DisabledScope(!IgnoreCubemaps))
-                    {
-                        OverrideCubemapSettingsWhen =
-                            (OverrideWhenSize)EditorGUILayout.EnumPopup("Ignore When", OverrideCubemapSettingsWhen);
-                        using (new EditorGUI.DisabledScope(OverrideCubemapSettingsWhen == OverrideWhenSize.Always))
-                        {
-                            CubemapSize = EditorGUILayout.IntPopup("Ignore Size", CubemapSize, maxTextureNames,
-                                maxTextureSizes);
-                        }
-                    }
-                }
-
-                IgnoreNormalMaps = EditorGUILayout.Toggle("Normal maps", IgnoreNormalMaps);
-
-                GUILayout.Space(5);
-                GUILayout.Label("Per-Platform Overrides", Styles.BoldWrap);
-
-                DrawPlatformSettings("PC (Standalone)", StandaloneSettings);
-                DrawPlatformSettings("Android", AndroidSettings);
-                DrawPlatformSettings("iOS", iOSSettings);
-            }
-
-            private void DrawPlatformSettings(string label, PlatformOverrideSettings settings)
-            {
-                using (new EditorGUILayout.VerticalScope(EditorStyles.helpBox))
-                {
-                    settings.Enabled = EditorGUILayout.ToggleLeft(label + " Override", settings.Enabled);
-                    using (new EditorGUI.DisabledScope(!settings.Enabled))
-                    using (new EditorGUI.IndentLevelScope())
-                    {
-                        settings.MaxTextureSize = EditorGUILayout.IntPopup("Max Size", settings.MaxTextureSize,
-                            maxTextureNames, maxTextureSizes);
-                        settings.CrunchCompression =
-                            EditorGUILayout.Toggle("Use Crunch Compression", settings.CrunchCompression);
-                        using (new EditorGUI.DisabledScope(!settings.CrunchCompression))
-                        {
-                            settings.CompressionQuality =
-                                EditorGUILayout.IntSlider("Quality", settings.CompressionQuality, 1, 100);
-                        }
-                    }
-                }
-            }
-
-            public void ProcessTextures(TextureDetails details)
-            {
-                try
-                {
-                    AssetDatabase.StartAssetEditing();
-
-                    var importers = details.GetImporters;
-                    var count = details.TextureCount;
-                    var current = 1;
-                    foreach (var importer in importers)
-                    {
-                        EditorUtility.DisplayProgressBar("Applying New Settings", importer.assetPath,
-                            (float)current / count);
-
-                        if (IgnoreNormalMaps && importer.textureType == TextureImporterType.NormalMap)
+                        if (material == null || checkedMaterials.Contains(material))
                             continue;
 
-                        if (IgnoreCubemaps && importer.textureShape == TextureImporterShape.TextureCube)
-                        {
-                            var oldMaxTextureSize = importer.maxTextureSize;
-                            var newMaxTextureSize = MaxTextureSize;
+                        checkedMaterials.Add(material);
 
-                            switch (OverrideCubemapSettingsWhen)
+                        var shader = material.shader;
+
+                        for (var l = 0; l < ShaderUtil.GetPropertyCount(shader); l++)
+                            if (ShaderUtil.GetPropertyType(shader, l) == ShaderUtil.ShaderPropertyType.TexEnv)
                             {
-                                case OverrideWhenSize.SmallerThan:
-                                    if (oldMaxTextureSize > newMaxTextureSize) continue;
-                                    break;
-                                case OverrideWhenSize.BiggerThan:
-                                    if (oldMaxTextureSize < newMaxTextureSize) continue;
-                                    break;
+                                var texture = material.GetTexture(ShaderUtil.GetPropertyName(shader, l));
+
+                                var textureImporter =
+                                    AssetImporter.GetAtPath(AssetDatabase.GetAssetPath(texture)) as TextureImporter;
+
+                                if (textureImporter != null) details.AddTexture(textureImporter, texture);
                             }
-                        }
-
-                        if (!DontChangeMipMaps)
-                        {
-                            importer.mipmapEnabled = GenerateMipMaps;
-                            importer.streamingMipmaps = StreamingMipMap;
-                        }
-
-                        if (!DontChangeAniso)
-                        {
-                            var oldAnisoLevel = importer.anisoLevel;
-                            var newAnisoLevel = AnisoLevel;
-
-                            switch (OverrideAnisoWhen)
-                            {
-                                case OverrideWhenSize.Always:
-                                    importer.anisoLevel = AnisoLevel;
-                                    break;
-                                case OverrideWhenSize.SmallerThan:
-                                    if (oldAnisoLevel < newAnisoLevel) importer.anisoLevel = newAnisoLevel;
-
-                                    break;
-                                case OverrideWhenSize.BiggerThan:
-                                    if (oldAnisoLevel > newAnisoLevel)
-                                        importer.maxTextureSize = newAnisoLevel; // existing behaviour
-
-                                    break;
-                            }
-                        }
-
-                        var skipCrunchCompression = false;
-
-                        if (DontOverrideCrunchWhen != DontOverrideWhen.Never)
-                            switch (DontOverrideCrunchWhen)
-                            {
-                                case DontOverrideWhen.AlreadyDisabled:
-                                    if (!importer.crunchedCompression) skipCrunchCompression = true;
-                                    break;
-                                case DontOverrideWhen.AlreadyEnabled:
-                                    if (importer.crunchedCompression) skipCrunchCompression = true;
-                                    break;
-                            }
-
-                        if (!skipCrunchCompression)
-                        {
-                            var oldMaxTextureSize = importer.maxTextureSize;
-                            var newMaxTextureSize = MaxTextureSize;
-                            importer.crunchedCompression = CrunchCompression;
-
-                            if (importer.crunchedCompression)
-                                switch (OverrideMaxTextureSizeWhen)
-                                {
-                                    case OverrideWhenSize.Always:
-                                        importer.maxTextureSize = newMaxTextureSize;
-                                        break;
-                                    case OverrideWhenSize.SmallerThan:
-                                        if (oldMaxTextureSize < newMaxTextureSize)
-                                            importer.maxTextureSize = newMaxTextureSize;
-
-                                        break;
-                                    case OverrideWhenSize.BiggerThan:
-                                        if (oldMaxTextureSize > newMaxTextureSize)
-                                            importer.maxTextureSize = newMaxTextureSize;
-
-                                        break;
-                                }
-                        }
-
-                        if (!DontChangeCompressionQuality)
-                            if (!(ignoreNoneCompression &&
-                                  importer.textureCompression == TextureImporterCompression.Uncompressed))
-                                importer.textureCompression = TextureCompressionQuality;
-
-                        ApplyPlatformSettings(importer, "Standalone", StandaloneSettings, MaxTextureSize);
-                        ApplyPlatformSettings(importer, "Android", AndroidSettings, MaxTextureSize);
-                        ApplyPlatformSettings(importer, "iPhone", iOSSettings, MaxTextureSize);
-
-                        importer.SaveAndReimport();
-                        current++;
                     }
                 }
-                finally
-                {
-                    EditorUtility.ClearProgressBar();
-                    details.ResetStats();
-                    AssetDatabase.StopAssetEditing();
-                }
             }
 
-            private static void ApplyPlatformSettings(TextureImporter importer, string platformName,
-                PlatformOverrideSettings settings, int fallbackMaxSize)
-            {
-                if (!settings.Enabled)
-                    return;
-
-                var pts = importer.GetPlatformTextureSettings(platformName);
-                if (pts == null) pts = new TextureImporterPlatformSettings();
-
-                pts.name = platformName;
-                pts.overridden = true;
-
-                pts.maxTextureSize = settings.MaxTextureSize > 0 ? settings.MaxTextureSize : fallbackMaxSize;
-                pts.crunchedCompression = settings.CrunchCompression;
-                if (settings.CrunchCompression) pts.compressionQuality = settings.CompressionQuality;
-
-                importer.SetPlatformTextureSettings(pts);
-            }
-
-            // Per-platform overrides
-            [Serializable]
-            public class PlatformOverrideSettings
-            {
-                public bool Enabled;
-                public int MaxTextureSize = 2048;
-                public bool CrunchCompression = true;
-                public int CompressionQuality = 80;
-            }
+            EditorUtility.ClearProgressBar();
+            return details;
         }
 
-        public class MassTextureImporter : EditorWindow
+        private static TextureDetails GetAllTexturesFromAssets()
         {
-            private TextureDetails details = new();
+            var details = new TextureDetails();
 
-            private ImporterSettingsManager importerSettingsManager = new();
+            var assetGuidStrings = AssetDatabase.FindAssets("t:texture2D", new[] { "Assets" });
 
-            private Vector2 scrollPos;
-
-            private void OnGUI()
+            var assetsLength = assetGuidStrings.Length;
+            for (var i = 0; i < assetsLength; i++)
             {
-                GUILayout.Label("Selected Textures", Styles.BoldWrap);
-                using (new EditorGUILayout.HorizontalScope(EditorStyles.helpBox))
-                {
-                    using (new EditorGUILayout.VerticalScope())
-                    {
-                        GUILayout.Label("<b>Texture Count:</b> " + details.TextureCount, Styles.LabelRichText);
-                        GUILayout.Label("<b>Uncrunched Count:</b> " + details.UncrunchedCount, Styles.LabelRichText);
-                        GUILayout.Label("<b>Storage Size:</b> " + EditorUtility.FormatBytes(details.StorageSize),
-                            Styles.LabelRichText);
-                    }
+                var path = AssetDatabase.GUIDToAssetPath(assetGuidStrings[i]);
 
-                    using (new EditorGUILayout.VerticalScope())
-                    {
-                        GUILayout.Label("<b>Normal Maps:</b> " + details.NormalMaps, Styles.LabelRichText);
-                        GUILayout.Label("<b>Cubemaps:</b> " + details.Cubemaps, Styles.LabelRichText);
-                    }
-                }
+                if (EditorUtility.DisplayCancelableProgressBar("Getting All Textures from Assets",
+                        Path.GetFileName(path), (float)i / assetsLength)) break;
 
-                importerSettingsManager.DrawSettings();
+                var texture = AssetDatabase.LoadAssetAtPath<Texture>(path);
+                var textureImporter = AssetImporter.GetAtPath(path) as TextureImporter;
 
-                GUILayout.Space(5);
-
-                GUILayout.Label("Get textures from:");
-
-                using (new EditorGUILayout.HorizontalScope())
-                {
-                    if (GUILayout.Button("Scene", GUILayout.Width(70), GUILayout.Height(20)))
-                        details = GetAllTexturesFromScene();
-
-                    if (GUILayout.Button("Assets", GUILayout.Width(70), GUILayout.Height(20)))
-                        details = GetAllTexturesFromAssets();
-
-                    GUILayout.FlexibleSpace();
-
-                    if (GUILayout.Button("Revert", GUILayout.Width(70), GUILayout.Height(20)))
-                        importerSettingsManager = new ImporterSettingsManager();
-
-                    if (GUILayout.Button("Apply", GUILayout.Width(70), GUILayout.Height(20)))
-                        if (EditorUtility.DisplayDialog("Process Importers?",
-                                $"About to process Texture Import settings on {details.TextureCount} textures, this can take a while depending on the amount and size of them.\n\nDo you want to continue?",
-                                "Ok", "Cancel"))
-                            importerSettingsManager.ProcessTextures(details);
-                }
+                details.AddTexture(textureImporter, texture);
             }
 
-            [MenuItem("VRWorld Toolkit/Quick Functions/Mass Texture Importer", false, 4)]
-            public static void ShowWindow()
-            {
-                var window = GetWindow(typeof(MassTextureImporter));
-                window.titleContent = new GUIContent("Mass Texture Importer");
-                window.minSize = new Vector2(400, 530);
-                window.Show();
-            }
-
-            private static TextureDetails GetAllTexturesFromScene()
-            {
-                var details = new TextureDetails();
-                var checkedMaterials = new List<Material>();
-
-                var allGameObjects = Resources.FindObjectsOfTypeAll(typeof(GameObject));
-                var allGameObjectsLength = allGameObjects.Length;
-                for (var i = 0; i < allGameObjectsLength; i++)
-                {
-                    var gameObject = allGameObjects[i] as GameObject;
-
-                    if (gameObject.hideFlags != HideFlags.None ||
-                        EditorUtility.IsPersistent(gameObject.transform.root.gameObject)) continue;
-
-                    if (EditorUtility.DisplayCancelableProgressBar("Getting All Textures from Scene", gameObject.name,
-                            (float)i / allGameObjectsLength)) break;
-
-                    var renderers = gameObject.GetComponents<Renderer>();
-                    for (var j = 0; j < renderers.Length; j++)
-                    {
-                        var renderer = renderers[j];
-                        for (var k = 0; k < renderer.sharedMaterials.Length; k++)
-                        {
-                            var material = renderer.sharedMaterials[k];
-
-                            if (material == null || checkedMaterials.Contains(material))
-                                continue;
-
-                            checkedMaterials.Add(material);
-
-                            var shader = material.shader;
-
-                            for (var l = 0; l < ShaderUtil.GetPropertyCount(shader); l++)
-                                if (ShaderUtil.GetPropertyType(shader, l) == ShaderUtil.ShaderPropertyType.TexEnv)
-                                {
-                                    var texture = material.GetTexture(ShaderUtil.GetPropertyName(shader, l));
-
-                                    var textureImporter =
-                                        AssetImporter.GetAtPath(AssetDatabase.GetAssetPath(texture)) as TextureImporter;
-
-                                    if (textureImporter != null) details.AddTexture(textureImporter, texture);
-                                }
-                        }
-                    }
-                }
-
-                EditorUtility.ClearProgressBar();
-                return details;
-            }
-
-            private static TextureDetails GetAllTexturesFromAssets()
-            {
-                var details = new TextureDetails();
-
-                var assetGuidStrings = AssetDatabase.FindAssets("t:texture2D", new[] { "Assets" });
-
-                var assetsLength = assetGuidStrings.Length;
-                for (var i = 0; i < assetsLength; i++)
-                {
-                    var path = AssetDatabase.GUIDToAssetPath(assetGuidStrings[i]);
-
-                    if (EditorUtility.DisplayCancelableProgressBar("Getting All Textures from Assets",
-                            Path.GetFileName(path), (float)i / assetsLength)) break;
-
-                    var texture = AssetDatabase.LoadAssetAtPath<Texture>(path);
-                    var textureImporter = AssetImporter.GetAtPath(path) as TextureImporter;
-
-                    details.AddTexture(textureImporter, texture);
-                }
-
-                EditorUtility.ClearProgressBar();
-                return details;
-            }
+            EditorUtility.ClearProgressBar();
+            return details;
         }
     }
-}
-
-public class MassTextureImporter : EditorWindow
-{
-    private TextureDetails details = new();
-
-    private ImporterSettingsManager importerSettingsManager = new();
-
-    private Vector2 scrollPos;
-
-    private void OnGUI()
-    {
-        GUILayout.Label("Selected Textures", Styles.BoldWrap);
-        using (new EditorGUILayout.HorizontalScope(EditorStyles.helpBox))
-        {
-            using (new EditorGUILayout.VerticalScope())
-            {
-                GUILayout.Label("<b>Texture Count:</b> " + details.TextureCount, Styles.LabelRichText);
-                GUILayout.Label("<b>Uncrunched Count:</b> " + details.UncrunchedCount, Styles.LabelRichText);
-                GUILayout.Label("<b>Storage Size:</b> " + EditorUtility.FormatBytes(details.StorageSize),
-                    Styles.LabelRichText);
-            }
-
-            using (new EditorGUILayout.VerticalScope())
-            {
-                GUILayout.Label("<b>Normal Maps:</b> " + details.NormalMaps, Styles.LabelRichText);
-                GUILayout.Label("<b>Cubemaps:</b> " + details.Cubemaps, Styles.LabelRichText);
-            }
-        }
-
-        importerSettingsManager.DrawSettings();
-
-        GUILayout.Space(5);
-
-        GUILayout.Label("Get textures from:");
-
-        using (new EditorGUILayout.HorizontalScope())
-        {
-            if (GUILayout.Button("Scene", GUILayout.Width(70), GUILayout.Height(20)))
-                details = GetAllTexturesFromScene();
-
-            if (GUILayout.Button("Assets", GUILayout.Width(70), GUILayout.Height(20)))
-                details = GetAllTexturesFromAssets();
-
-            GUILayout.FlexibleSpace();
-
-            if (GUILayout.Button("Revert", GUILayout.Width(70), GUILayout.Height(20)))
-                importerSettingsManager = new ImporterSettingsManager();
-
-            if (GUILayout.Button("Apply", GUILayout.Width(70), GUILayout.Height(20)))
-                if (EditorUtility.DisplayDialog("Process Importers?",
-                        $"About to process Texture Import settings on {details.TextureCount} textures, this can take a while depending on the amount and size of them.\n\nDo you want to continue?",
-                        "Ok", "Cancel"))
-                    importerSettingsManager.ProcessTextures(details);
-        }
-    }
-
-    [MenuItem("VRWorld Toolkit/Quick Functions/Mass Texture Importer", false, 4)]
-    public static void ShowWindow()
-    {
-        var window = GetWindow(typeof(MassTextureImporter));
-        window.titleContent = new GUIContent("Mass Texture Importer");
-        window.minSize = new Vector2(400, 530);
-        window.Show();
-    }
-
-    private static TextureDetails GetAllTexturesFromScene()
-    {
-        var details = new TextureDetails();
-        var checkedMaterials = new List<Material>();
-
-        var allGameObjects = Resources.FindObjectsOfTypeAll(typeof(GameObject));
-        var allGameObjectsLength = allGameObjects.Length;
-        for (var i = 0; i < allGameObjectsLength; i++)
-        {
-            var gameObject = allGameObjects[i] as GameObject;
-
-            if (gameObject.hideFlags != HideFlags.None ||
-                EditorUtility.IsPersistent(gameObject.transform.root.gameObject)) continue;
-
-            if (EditorUtility.DisplayCancelableProgressBar("Getting All Textures from Scene", gameObject.name,
-                    (float)i / allGameObjectsLength)) break;
-
-            var renderers = gameObject.GetComponents<Renderer>();
-            for (var j = 0; j < renderers.Length; j++)
-            {
-                var renderer = renderers[j];
-                for (var k = 0; k < renderer.sharedMaterials.Length; k++)
-                {
-                    var material = renderer.sharedMaterials[k];
-
-                    if (material == null || checkedMaterials.Contains(material))
-                        continue;
-
-                    checkedMaterials.Add(material);
-
-                    var shader = material.shader;
-
-                    for (var l = 0; l < ShaderUtil.GetPropertyCount(shader); l++)
-                        if (ShaderUtil.GetPropertyType(shader, l) == ShaderUtil.ShaderPropertyType.TexEnv)
-                        {
-                            var texture = material.GetTexture(ShaderUtil.GetPropertyName(shader, l));
-
-                            var textureImporter =
-                                AssetImporter.GetAtPath(AssetDatabase.GetAssetPath(texture)) as TextureImporter;
-
-                            if (textureImporter != null) details.AddTexture(textureImporter, texture);
-                        }
-                }
-            }
-        }
-
-        EditorUtility.ClearProgressBar();
-        return details;
-    }
-
-    private static TextureDetails GetAllTexturesFromAssets()
-    {
-        var details = new TextureDetails();
-
-        var assetGuidStrings = AssetDatabase.FindAssets("t:texture2D", new[] { "Assets" });
-
-        var assetsLength = assetGuidStrings.Length;
-        for (var i = 0; i < assetsLength; i++)
-        {
-            var path = AssetDatabase.GUIDToAssetPath(assetGuidStrings[i]);
-
-            if (EditorUtility.DisplayCancelableProgressBar("Getting All Textures from Assets",
-                    Path.GetFileName(path), (float)i / assetsLength)) break;
-
-            var texture = AssetDatabase.LoadAssetAtPath<Texture>(path);
-            var textureImporter = AssetImporter.GetAtPath(path) as TextureImporter;
-
-            details.AddTexture(textureImporter, texture);
-        }
-
-        EditorUtility.ClearProgressBar();
-        return details;
-    }
-}
-
 }


### PR DESCRIPTION
This allows setting Max Size and Crunch Compression settings per-platform of PC (Standalone), Android and iOS. This easily helps a ton for build sizes across PC and mobile platforms.

<img width="892" height="298" alt="image" src="https://github.com/user-attachments/assets/74b47afa-4937-4569-9d06-ba5bca011a8c" />
