### PR TITLE
Project Settings Asset + Default UdonBehaviour Sync Mode

### DIFF
--- a/Editor/DefaultUdonBehaviourSyncModeAssigner.cs
+++ b/Editor/DefaultUdonBehaviourSyncModeAssigner.cs
@@ -1,4 +1,7 @@
 #if VRC_SDK_VRCSDK3 && UDON
+using System;
+using System.Linq;
+using System.Threading.Tasks;
 using UnityEditor;
 using UnityEngine;
 using VRC.SDK3.Components;
@@ -8,6 +11,8 @@ namespace VRWorldToolkit.Editor
 {
     public static class DefaultUdonBehaviourSyncModeAssigner
     {
+        private static bool waitingOnInspectorUpdate;
+        
         [InitializeOnLoadMethod]
         public static void Init()
         {
@@ -18,6 +23,51 @@ namespace VRWorldToolkit.Editor
         {
             if (component is AbstractUdonBehaviour udonBehaviour)
                 udonBehaviour.SyncMethod = Networking.SyncType.None;
+            // Wait a brief moment for any additional UdonBehaviours being added outside UnityEditor.ObjectFactory (like from UdonSharp).
+            else
+                CheckForPostAdditionalComponents(component, component.GetComponents<AbstractUdonBehaviour>());
+        }
+
+        private static async void CheckForPostAdditionalComponents(Component component, AbstractUdonBehaviour[] previousUdonBehaviours)
+        {
+            try
+            {
+                if (!component)
+                    return;
+
+                waitingOnInspectorUpdate = true;
+                EditorApplication.delayCall += DelayCalledInspector;
+                
+                while (waitingOnInspectorUpdate)
+                    await Task.Yield();
+            
+                AbstractUdonBehaviour[] newUdonBehaviours = component.GetComponents<AbstractUdonBehaviour>();
+            
+                if (newUdonBehaviours == null)
+                    return;
+
+                if (previousUdonBehaviours == null)
+                    previousUdonBehaviours = Array.Empty<AbstractUdonBehaviour>();
+                
+                // Check for newly added UdonBehaviours that didn't exist before.
+                foreach (AbstractUdonBehaviour udonBehaviour in newUdonBehaviours)
+                {
+                    if (previousUdonBehaviours.Contains(udonBehaviour))
+                        continue;
+                    
+                    if (udonBehaviour)
+                        udonBehaviour.SyncMethod = Networking.SyncType.None;
+                }
+            }
+            catch (Exception)
+            {
+                // Ignore
+            }
+        }
+        
+        private static void DelayCalledInspector()
+        {
+            waitingOnInspectorUpdate = false;
         }
     }
 }

--- a/Editor/DefaultUdonBehaviourSyncModeAssigner.cs
+++ b/Editor/DefaultUdonBehaviourSyncModeAssigner.cs
@@ -1,0 +1,24 @@
+#if VRC_SDK_VRCSDK3 && UDON
+using UnityEditor;
+using UnityEngine;
+using VRC.SDK3.Components;
+using VRC.SDKBase;
+
+namespace VRWorldToolkit.Editor
+{
+    public static class DefaultUdonBehaviourSyncModeAssigner
+    {
+        [InitializeOnLoadMethod]
+        public static void Init()
+        {
+            ObjectFactory.componentWasAdded += OnAddComponent;
+        }
+        
+        private static void OnAddComponent(Component component)
+        {
+            if (component is AbstractUdonBehaviour udonBehaviour)
+                udonBehaviour.SyncMethod = Networking.SyncType.None;
+        }
+    }
+}
+#endif

--- a/Editor/DefaultUdonBehaviourSyncModeAssigner.cs
+++ b/Editor/DefaultUdonBehaviourSyncModeAssigner.cs
@@ -21,8 +21,11 @@ namespace VRWorldToolkit.Editor
         
         private static void OnAddComponent(Component component)
         {
+            if (VRWorldToolkitSettings.GetOrCreateSettings().defaultUdonBehaviourSyncMode == VRWorldToolkitSettings.AssignUdonBehaviourSyncMode.Ignore)
+                return;
+            
             if (component is AbstractUdonBehaviour udonBehaviour)
-                udonBehaviour.SyncMethod = Networking.SyncType.None;
+                udonBehaviour.SyncMethod = GetUdonBehaviourSyncModeFromSettings();
             // Wait a brief moment for any additional UdonBehaviours being added outside UnityEditor.ObjectFactory (like from UdonSharp).
             else
                 CheckForPostAdditionalComponents(component, component.GetComponents<AbstractUdonBehaviour>());
@@ -56,7 +59,7 @@ namespace VRWorldToolkit.Editor
                         continue;
                     
                     if (udonBehaviour)
-                        udonBehaviour.SyncMethod = Networking.SyncType.None;
+                        udonBehaviour.SyncMethod = GetUdonBehaviourSyncModeFromSettings();
                 }
             }
             catch (Exception)
@@ -68,6 +71,21 @@ namespace VRWorldToolkit.Editor
         private static void DelayCalledInspector()
         {
             waitingOnInspectorUpdate = false;
+        }
+
+        private static Networking.SyncType GetUdonBehaviourSyncModeFromSettings()
+        {
+            switch (VRWorldToolkitSettings.GetOrCreateSettings().defaultUdonBehaviourSyncMode)
+            {
+                case VRWorldToolkitSettings.AssignUdonBehaviourSyncMode.Continuous:
+                    return Networking.SyncType.Continuous;
+                case VRWorldToolkitSettings.AssignUdonBehaviourSyncMode.Manual:
+                    return Networking.SyncType.Manual;
+                case VRWorldToolkitSettings.AssignUdonBehaviourSyncMode.None:
+                    return Networking.SyncType.None;
+            }
+
+            return default;
         }
     }
 }

--- a/Editor/DefaultUdonBehaviourSyncModeAssigner.cs.meta
+++ b/Editor/DefaultUdonBehaviourSyncModeAssigner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 85d451e20caf80a4eb22a9cd6381d808
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/VRWorldToolkitSettings.cs
+++ b/Editor/VRWorldToolkitSettings.cs
@@ -15,7 +15,7 @@ namespace VRWorldToolkit.Editor
         {
             VRWorldToolkitSettings settings = CreateInstance<VRWorldToolkitSettings>();
             CheckOrCreateDirectoryPath(defaultSettingsPath);
-            AssetDatabase.CreateAsset(settings, $"{path}VRWorldToolkitSettings.asset");
+            AssetDatabase.CreateAsset(settings, $"{path}VRWorld Toolkit Settings.asset");
             EditorUtility.SetDirty(settings);
             AssetDatabase.SaveAssetIfDirty(settings);
             return settings;
@@ -54,7 +54,7 @@ namespace VRWorldToolkit.Editor
         {
             VRWorldToolkitSettings currentSettingsAsset = null;
             
-            string[] foundAssetGUIDs = AssetDatabase.FindAssets("t:ScriptableObject VRWorldToolkitSettings");
+            string[] foundAssetGUIDs = AssetDatabase.FindAssets("t:ScriptableObject VRWorld Toolkit Settings");
             if (foundAssetGUIDs != null)
             {
                 foreach (string foundAssetGUID in foundAssetGUIDs)

--- a/Editor/VRWorldToolkitSettings.cs
+++ b/Editor/VRWorldToolkitSettings.cs
@@ -1,0 +1,74 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace VRWorldToolkit.Editor
+{
+    public class VRWorldToolkitSettings : ScriptableObject
+    {
+        private const string defaultSettingsPath = "Assets/VRWorld Toolkit/";
+
+        public enum AssignUdonBehaviourSyncMode { Ignore, Continuous, Manual, None }
+        [Tooltip("Specifies the Sync Mode to assign by default to newly created UdonBehaviours. Ignore will leave the UdonBehaviour as the VRChat SDK default.")]
+        public AssignUdonBehaviourSyncMode defaultUdonBehaviourSyncMode = AssignUdonBehaviourSyncMode.None;
+        
+        private static VRWorldToolkitSettings CreateSettings(string path)
+        {
+            VRWorldToolkitSettings settings = CreateInstance<VRWorldToolkitSettings>();
+            CheckOrCreateDirectoryPath(defaultSettingsPath);
+            AssetDatabase.CreateAsset(settings, $"{path}VRWorldToolkitSettings.asset");
+            EditorUtility.SetDirty(settings);
+            AssetDatabase.SaveAssetIfDirty(settings);
+            return settings;
+        }
+
+        private static void CheckOrCreateDirectoryPath(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+                return;
+            
+            // Assuming '/' is separator, this may need to be changed for other file path systems.
+            if (!path.Contains('/'))
+                return;
+            
+            string[] directories = path.Split('/');
+            string pathing = directories[0];
+            for (int i = 1; i < directories.Length; i++)
+            {
+                if (string.IsNullOrWhiteSpace(directories[i]))
+                    continue;
+
+                if (!AssetDatabase.IsValidFolder($"{pathing}/{directories[i]}"))
+                {
+                    Debug.Log($"{pathing}, {directories[i]}");
+                    AssetDatabase.CreateFolder(pathing, directories[i]);
+                }
+
+                pathing += "/" + directories[i];
+            }
+            
+            AssetDatabase.SaveAssets();
+            AssetDatabase.Refresh();
+        }
+        
+        public static VRWorldToolkitSettings GetOrCreateSettings()
+        {
+            VRWorldToolkitSettings currentSettingsAsset = null;
+            
+            string[] foundAssetGUIDs = AssetDatabase.FindAssets("t:ScriptableObject VRWorldToolkitSettings");
+            if (foundAssetGUIDs != null)
+            {
+                foreach (string foundAssetGUID in foundAssetGUIDs)
+                {
+                    currentSettingsAsset = AssetDatabase.LoadAssetAtPath<VRWorldToolkitSettings>(AssetDatabase.GUIDToAssetPath(foundAssetGUID));
+                    if (currentSettingsAsset)
+                        return currentSettingsAsset;
+                }
+            }
+            
+            if (!currentSettingsAsset)
+                currentSettingsAsset = CreateSettings(defaultSettingsPath);
+
+            return currentSettingsAsset;
+        }
+    }
+}

--- a/Editor/VRWorldToolkitSettings.cs.meta
+++ b/Editor/VRWorldToolkitSettings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 461e334a38c251644ad7e3266f1000a2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/VRWorldToolkitSettingsProvider.cs
+++ b/Editor/VRWorldToolkitSettingsProvider.cs
@@ -1,0 +1,29 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+namespace VRWorldToolkit.Editor
+{
+    public class VRWorldToolkitSettingsProvider : SettingsProvider
+    {
+        private VRWorldToolkitSettings settingsInstance;
+        
+        public VRWorldToolkitSettingsProvider(string path, SettingsScope scopes, IEnumerable<string> keywords = null) : base(path, scopes, keywords) {}
+
+        [SettingsProvider]
+        public static SettingsProvider CreateSettingsProvider()
+        {
+            return new VRWorldToolkitSettingsProvider("Project/VRWorldToolkit", SettingsScope.Project);
+        }
+
+        public override void OnGUI(string searchContext)
+        {
+            if (!settingsInstance)
+                settingsInstance = VRWorldToolkitSettings.GetOrCreateSettings();
+            
+            SerializedObject serializedObject = new SerializedObject(settingsInstance);
+            EditorGUILayout.PropertyField(serializedObject.FindProperty(nameof(settingsInstance.defaultUdonBehaviourSyncMode)));
+        }
+    }
+}

--- a/Editor/VRWorldToolkitSettingsProvider.cs
+++ b/Editor/VRWorldToolkitSettingsProvider.cs
@@ -14,7 +14,7 @@ namespace VRWorldToolkit.Editor
         [SettingsProvider]
         public static SettingsProvider CreateSettingsProvider()
         {
-            return new VRWorldToolkitSettingsProvider("Project/VRWorldToolkit", SettingsScope.Project);
+            return new VRWorldToolkitSettingsProvider("Project/VRWorld Toolkit", SettingsScope.Project);
         }
 
         public override void OnGUI(string searchContext)

--- a/Editor/VRWorldToolkitSettingsProvider.cs.meta
+++ b/Editor/VRWorldToolkitSettingsProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ecfe54007bb2450448bf04ceee631eec
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This adds two things:
# Project Settings Asset
- New VRWorld Toolkit Settings Asset for Project Settings pertaining to VRWorld Toolkit (like the new default UdonBehaviour Sync Mode to apply).
- Searches automatically in the project for one before creating a new one in a default folder.
# Default UdonBehaviour Sync Mode
- When not set to Ignore, all UdonBehaviours added to the scene will take on the mode defined in the Project Settings.
- By default this is set to None, which defaults all newly created UdonBehaviours (including U# scripts) to None sync.